### PR TITLE
app: Apply Knox Matrix patch on Android 13 too

### DIFF
--- a/app/src/main/res/values-v33/arrays.xml
+++ b/app/src/main/res/values-v33/arrays.xml
@@ -9,6 +9,7 @@
         <item>com.samsung.android.galaxycontinuity</item>
         <item>com.samsung.android.privateshare</item>
         <item>com.samsung.android.scloud</item>
+        <item>com.samsung.android.kmxservice</item>
         <item>com.samsung.android.scpm</item>
         <item>com.samsung.android.shealthmonitor</item>
         <item>com.samsung.android.spay</item>


### PR DESCRIPTION
Samsung One UI 5.1.1 (Android 13) includes Enhanced Data Protection feature and requires proper patching like Android 14 devices.