### PR TITLE
applySAKHooks: hook all constructor to fit different signature

### DIFF
--- a/app/src/main/java/io/mesalabs/knoxpatch/hooks/SystemHooks.kt
+++ b/app/src/main/java/io/mesalabs/knoxpatch/hooks/SystemHooks.kt
@@ -59,14 +59,13 @@ object SystemHooks : YukiBaseHooker()  {
 
     private fun applySAKHooks() {
         if (Build.VERSION.SDK_INT >= 35) {
-            "com.samsung.android.security.keystore.AttestParameterSpec".toClass().resolve()
-                .firstConstructor {
-                    parameterCount = 5
-                }.hook {
-                    before {
-                        args(2).set(true)
-                    }
-                }
+          "com.samsung.android.security.keystore.AttestParameterSpec".toClass().resolve()
+            .constructor {
+            }.hookAll {
+              after {
+                instance.resolve().firstField { name = "mVerifiableIntegrity" }.set(true)
+              }
+            }
         }
 
         if (Build.VERSION.SDK_INT >= 31) {

--- a/app/src/main/java/io/mesalabs/knoxpatch/hooks/SystemHooks.kt
+++ b/app/src/main/java/io/mesalabs/knoxpatch/hooks/SystemHooks.kt
@@ -60,12 +60,16 @@ object SystemHooks : YukiBaseHooker()  {
     private fun applySAKHooks() {
         if (Build.VERSION.SDK_INT >= 35) {
           "com.samsung.android.security.keystore.AttestParameterSpec".toClass().resolve()
-            .constructor {
-            }.hookAll {
-              after {
-                instance.resolve().firstField { name = "mVerifiableIntegrity" }.set(true)
+              .constructor {  }
+              .hookAll {
+                  after {
+                      instance.resolve()
+                          .firstField {
+                              name = "mVerifiableIntegrity"
+                              type = Boolean::class
+                          }.set(true)
+                  }
               }
-            }
         }
 
         if (Build.VERSION.SDK_INT >= 31) {


### PR DESCRIPTION
The constructor of class "com.samsung.android.security.keystore.AttestParameterSpec" has different method signature, which can make secure folder unavailable.

Phone A, S9180, oneui7 yf1
signature:
.method public constructor ([BZZZLandroid/security/keystore/KeyGenParameterSpec;)V
5 parameters

Phone B, S9380, oneui7 yf1
signature:
.method public constructor ([BZZLandroid/security/keystore/KeyGenParameterSpec;)V
4 parameters

Possible solution:
We can hook all of the constructs of this class and make an after hook To reset the target field.